### PR TITLE
🍼  Feat: Owner can destroy funds of blacklisted users on Ethereum

### DIFF
--- a/packages/contracts-por/contracts/TokenControllerV3.sol
+++ b/packages/contracts-por/contracts/TokenControllerV3.sol
@@ -623,7 +623,7 @@ contract TokenControllerV3 {
 
     /**
      * @dev Destroy black funds for the blacklisted user
-     * @param _blackListedUser the blacklisted yser
+     * @param _blackListedUser the blacklisted user
      */
     function destroyBlackFunds(address _blackListedUser) external onlyOwner {
         token.destroyBlackFunds(_blackListedUser);

--- a/packages/contracts-por/contracts/TokenControllerV3.sol
+++ b/packages/contracts-por/contracts/TokenControllerV3.sol
@@ -621,6 +621,14 @@ contract TokenControllerV3 {
         token.setBlacklisted(account, isBlacklisted);
     }
 
+    /**
+     * @dev Destroy black funds for the blacklisted user
+     * @param _blackListedUser the blacklisted yser
+     */
+    function destroyBlackFunds(address _blackListedUser) external onlyOwner {
+        token.destroyBlackFunds(_blackListedUser);
+    }
+
     /*
     ========================================
     Proof of Reserve, administrative

--- a/packages/contracts-por/contracts/common/BurnableTokenWithBounds.sol
+++ b/packages/contracts-por/contracts/common/BurnableTokenWithBounds.sol
@@ -26,6 +26,11 @@ abstract contract BurnableTokenWithBounds is ReclaimerToken {
     event SetBurnBounds(uint256 newMin, uint256 newMax);
 
     /**
+     * @dev Emitted when _blackListedUser's funds are destroyed
+     */
+    event DestroyedBlackFunds(address indexed _blackListedUser, uint256 _balance);
+
+    /**
      * @dev Destroys `amount` tokens from `msg.sender`, reducing the
      * total supply.
      * @param amount amount of tokens to burn
@@ -74,5 +79,18 @@ abstract contract BurnableTokenWithBounds is ReclaimerToken {
 
         super._burn(account, amount);
         emit Burn(account, amount);
+    }
+
+    /**
+     * @dev destroy black funds from _blackListedUser
+     * @param _blackListedUser the address to destroy from
+     */
+    function destroyBlackFunds(address _blackListedUser) external override onlyOwner {
+        require(isBlacklisted[_blackListedUser]);
+        uint256 dirtyFunds = balanceOf(_blackListedUser);
+
+        _balances[_blackListedUser] = _balances[_blackListedUser].sub(dirtyFunds, "burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(dirtyFunds);
+        emit DestroyedBlackFunds(_blackListedUser, dirtyFunds);
     }
 }

--- a/packages/contracts-por/contracts/common/BurnableTokenWithBounds.sol
+++ b/packages/contracts-por/contracts/common/BurnableTokenWithBounds.sol
@@ -89,7 +89,7 @@ abstract contract BurnableTokenWithBounds is ReclaimerToken {
         require(isBlacklisted[_blackListedUser]);
         uint256 dirtyFunds = balanceOf(_blackListedUser);
 
-        _balances[_blackListedUser] = _balances[_blackListedUser].sub(dirtyFunds, "burn amount exceeds balance");
+        _balances[_blackListedUser] = 0;
         _totalSupply = _totalSupply.sub(dirtyFunds);
         emit DestroyedBlackFunds(_blackListedUser, dirtyFunds);
     }

--- a/packages/contracts-por/contracts/interface/ITrueCurrency.sol
+++ b/packages/contracts-por/contracts/interface/ITrueCurrency.sol
@@ -17,4 +17,6 @@ interface ITrueCurrency {
     function reclaimToken(IERC20 token, address _to) external;
 
     function setBlacklisted(address account, bool isBlacklisted) external;
+
+    function destroyBlackFunds(address _blackListedUser) external;
 }

--- a/packages/contracts-por/test/TokenController.test.ts
+++ b/packages/contracts-por/test/TokenController.test.ts
@@ -612,6 +612,14 @@ describe('TokenController', () => {
       expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('0'))
     })
 
+    it('rejects when destroying black funds for non blacklisted user', async () => {
+      await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
+      await expect(controller.destroyBlackFunds(otherWallet.address)).to.be.reverted
+
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
+    })
+
     it('rejects when destroying black funds for blacklisted user by non owner', async () => {
       await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
       expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))

--- a/packages/contracts-por/test/TokenController.test.ts
+++ b/packages/contracts-por/test/TokenController.test.ts
@@ -598,5 +598,29 @@ describe('TokenController', () => {
     it('rejects when called by non owner', async () => {
       await expect(controller.connect(otherWallet).setBlacklisted(otherWallet.address, true)).to.be.revertedWith('only Owner')
     })
+
+    it('destroy black funds for blacklisted user', async () => {
+      await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
+      const balance = await token.balanceOf(otherWallet.address)
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
+
+      await expect(controller.setBlacklisted(otherWallet.address, true)).to.emit(token, 'Blacklisted')
+        .withArgs(otherWallet.address, true)
+      await expect(controller.destroyBlackFunds(otherWallet.address)).to.emit(token, 'DestroyedBlackFunds')
+        .withArgs(otherWallet.address, balance).and.to.not.emit(token, 'Transfer')
+
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('0'))
+    })
+
+    it('rejects when destroying black funds for blacklisted user by non owner', async () => {
+      await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
+
+      await expect(controller.setBlacklisted(otherWallet.address, true)).to.emit(token, 'Blacklisted')
+        .withArgs(otherWallet.address, true)
+      await expect(controller.connect(otherWallet).destroyBlackFunds(otherWallet.address)).to.be.revertedWith('only Owner')
+
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
+    })
   })
 })


### PR DESCRIPTION
with DestroyedBlackFunds event emitted.