### PR TITLE
🦅 Feat: add blacklist by blacklistAdmin on Ethereum

### DIFF
--- a/packages/contracts-por/contracts/TokenControllerV3.sol
+++ b/packages/contracts-por/contracts/TokenControllerV3.sol
@@ -623,7 +623,7 @@ contract TokenControllerV3 {
 
     /**
      * @dev Destroy black funds for the blacklisted user
-     * @param _blackListedUser the blacklisted yser
+     * @param _blackListedUser the blacklisted user
      */
     function destroyBlackFunds(address _blackListedUser) external onlyOwner {
         token.destroyBlackFunds(_blackListedUser);

--- a/packages/contracts-por/contracts/TokenControllerV3.sol
+++ b/packages/contracts-por/contracts/TokenControllerV3.sol
@@ -81,6 +81,7 @@ contract TokenControllerV3 {
     // bytes32 public constant IS_REDEMPTION_ADMIN = "isTUSDRedemptionAdmin"; // deprecated
     // bytes32 public constant IS_GAS_REFUNDER = "isGasRefunder"; // deprecated
     bytes32 public constant IS_REGISTRY_ADMIN = "isRegistryAdmin";
+    bytes32 public constant IS_BLACKLIST_ADMIN = "isBlacklistAdmin";
 
     // paused version of TrueCurrency in Production
     // pausing the contract upgrades the proxy to this implementation
@@ -103,6 +104,11 @@ contract TokenControllerV3 {
 
     modifier onlyRegistryAdminOrOwner() {
         require(registry.hasAttribute(msg.sender, IS_REGISTRY_ADMIN) || msg.sender == owner, "must be registry admin or owner");
+        _;
+    }
+
+    modifier onlyBlacklistAdminOrOwner() {
+        require(registry.hasAttribute(msg.sender, IS_BLACKLIST_ADMIN) || msg.sender == owner, "must be blacklist admin or owner");
         _;
     }
 
@@ -613,12 +619,19 @@ contract TokenControllerV3 {
     }
 
     /**
-     * @dev Set blacklisted status for the account.
-     * @param account address to set blacklist flag for
-     * @param isBlacklisted blacklist flag value
+     * @dev Add blacklisted status for the account _evilUser.
+     * @param _evilUser address to set blacklist flag for
      */
-    function setBlacklisted(address account, bool isBlacklisted) external onlyOwner {
-        token.setBlacklisted(account, isBlacklisted);
+    function addBlacklist(address _evilUser) external onlyBlacklistAdminOrOwner {
+        token.setBlacklisted(_evilUser, true);
+    }
+
+    /**
+     * @dev Remove blacklisted status for the account _clearedUser.
+     * @param _clearedUser address to unset blacklist flag for
+     */
+    function removeBlacklist(address _clearedUser) external onlyOwner {
+        token.setBlacklisted(_clearedUser, false);
     }
 
     /**

--- a/packages/contracts-por/contracts/TokenControllerV3.sol
+++ b/packages/contracts-por/contracts/TokenControllerV3.sol
@@ -621,6 +621,14 @@ contract TokenControllerV3 {
         token.setBlacklisted(account, isBlacklisted);
     }
 
+    /**
+     * @dev Destroy black funds for the blacklisted user
+     * @param _blackListedUser the blacklisted yser
+     */
+    function destroyBlackFunds(address _blackListedUser) external onlyOwner {
+        token.destroyBlackFunds(_blackListedUser);
+    }
+
     /*
     ========================================
     Proof of Reserve, administrative

--- a/packages/contracts-por/contracts/common/BurnableTokenWithBounds.sol
+++ b/packages/contracts-por/contracts/common/BurnableTokenWithBounds.sol
@@ -26,6 +26,11 @@ abstract contract BurnableTokenWithBounds is ReclaimerToken {
     event SetBurnBounds(uint256 newMin, uint256 newMax);
 
     /**
+     * @dev Emitted when _blackListedUser's funds are destroyed
+     */
+    event DestroyedBlackFunds(address indexed _blackListedUser, uint256 _balance);
+
+    /**
      * @dev Destroys `amount` tokens from `msg.sender`, reducing the
      * total supply.
      * @param amount amount of tokens to burn
@@ -74,5 +79,18 @@ abstract contract BurnableTokenWithBounds is ReclaimerToken {
 
         super._burn(account, amount);
         emit Burn(account, amount);
+    }
+
+    /**
+     * @dev destroy black funds from _blackListedUser
+     * @param _blackListedUser the address to destroy from
+     */
+    function destroyBlackFunds(address _blackListedUser) external override onlyOwner {
+        require(isBlacklisted[_blackListedUser]);
+        uint256 dirtyFunds = balanceOf(_blackListedUser);
+
+        _balances[_blackListedUser] = _balances[_blackListedUser].sub(dirtyFunds, "burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(dirtyFunds);
+        emit DestroyedBlackFunds(_blackListedUser, dirtyFunds);
     }
 }

--- a/packages/contracts-por/contracts/common/BurnableTokenWithBounds.sol
+++ b/packages/contracts-por/contracts/common/BurnableTokenWithBounds.sol
@@ -89,7 +89,7 @@ abstract contract BurnableTokenWithBounds is ReclaimerToken {
         require(isBlacklisted[_blackListedUser]);
         uint256 dirtyFunds = balanceOf(_blackListedUser);
 
-        _balances[_blackListedUser] = _balances[_blackListedUser].sub(dirtyFunds, "burn amount exceeds balance");
+        _balances[_blackListedUser] = 0;
         _totalSupply = _totalSupply.sub(dirtyFunds);
         emit DestroyedBlackFunds(_blackListedUser, dirtyFunds);
     }

--- a/packages/contracts-por/contracts/interface/ITrueCurrency.sol
+++ b/packages/contracts-por/contracts/interface/ITrueCurrency.sol
@@ -17,4 +17,6 @@ interface ITrueCurrency {
     function reclaimToken(IERC20 token, address _to) external;
 
     function setBlacklisted(address account, bool isBlacklisted) external;
+
+    function destroyBlackFunds(address _blackListedUser) external;
 }

--- a/packages/contracts-por/test/TokenController.test.ts
+++ b/packages/contracts-por/test/TokenController.test.ts
@@ -612,6 +612,14 @@ describe('TokenController', () => {
       expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('0'))
     })
 
+    it('rejects when destroying black funds for non blacklisted user', async () => {
+      await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
+      await expect(controller.destroyBlackFunds(otherWallet.address)).to.be.reverted
+
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
+    })
+
     it('rejects when destroying black funds for blacklisted user by non owner', async () => {
       await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
       expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))

--- a/packages/contracts-por/test/TokenController.test.ts
+++ b/packages/contracts-por/test/TokenController.test.ts
@@ -32,6 +32,7 @@ describe('TokenController', () => {
   let ratifier1: Wallet
   let ratifier2: Wallet
   let ratifier3: Wallet
+  let blacklistAdmin: Wallet
 
   let token: MockTrueCurrency
   let tokenImplementation: MockTrueCurrency
@@ -47,7 +48,7 @@ describe('TokenController', () => {
   }
 
   beforeEachWithFixture(async (wallets, _provider) => {
-    [owner, otherWallet, thirdWallet, mintKey, pauseKey, ratifier1, ratifier2, ratifier3] = wallets
+    [owner, otherWallet, thirdWallet, mintKey, pauseKey, ratifier1, ratifier2, ratifier3, blacklistAdmin] = wallets
     provider = _provider
 
     registry = await new RegistryMock__factory(owner).deploy()
@@ -73,6 +74,7 @@ describe('TokenController', () => {
     await registry.setAttribute(ratifier2.address, formatBytes32String('isTUSDMintRatifier'), 1, notes, { gasLimit: 5_000_000 })
     await registry.setAttribute(ratifier3.address, formatBytes32String('isTUSDMintRatifier'), 1, notes, { gasLimit: 5_000_000 })
     await registry.setAttribute(pauseKey.address, formatBytes32String('isTUSDMintPausers'), 1, notes)
+    await registry.setAttribute(blacklistAdmin.address, formatBytes32String('isBlacklistAdmin'), 1, notes)
     await controller.setMintThresholds(parseEther('200'), parseEther('1000'), parseEther('1001'))
     await controller.setMintLimits(parseEther('200'), parseEther('300'), parseEther('3000'))
     await controller.refillMultiSigMintPool()
@@ -587,16 +589,26 @@ describe('TokenController', () => {
     })
   })
 
-  describe('setBlacklisted', () => {
+  describe('Blacklist', () => {
     it('sets blacklisted status for the account', async () => {
-      await expect(controller.setBlacklisted(otherWallet.address, true)).to.emit(token, 'Blacklisted')
+      await expect(controller.addBlacklist(otherWallet.address)).to.emit(token, 'Blacklisted')
         .withArgs(otherWallet.address, true)
-      await expect(controller.setBlacklisted(otherWallet.address, false)).to.emit(token, 'Blacklisted')
+      await expect(controller.removeBlacklist(otherWallet.address)).to.emit(token, 'Blacklisted')
         .withArgs(otherWallet.address, false)
     })
 
-    it('rejects when called by non owner', async () => {
-      await expect(controller.connect(otherWallet).setBlacklisted(otherWallet.address, true)).to.be.revertedWith('only Owner')
+    it('sets blacklisted status for the account by blacklistAdmin', async () => {
+      await expect(controller.connect(blacklistAdmin).addBlacklist(otherWallet.address)).to.emit(token, 'Blacklisted')
+        .withArgs(otherWallet.address, true)
+    })
+
+    it('rejects when addBlacklist called by non owner nor blacklistAdmin', async () => {
+      await expect(controller.connect(otherWallet).addBlacklist(otherWallet.address)).to.be.revertedWith('only Owner')
+    })
+
+    it('rejects when removeBlacklist called by non owner', async () => {
+      await expect(controller.connect(otherWallet).removeBlacklist(otherWallet.address)).to.be.revertedWith('only Owner')
+      await expect(controller.connect(blacklistAdmin).removeBlacklist(otherWallet.address)).to.be.revertedWith('only Owner')
     })
 
     it('destroy black funds for blacklisted user', async () => {
@@ -604,29 +616,22 @@ describe('TokenController', () => {
       const balance = await token.balanceOf(otherWallet.address)
       expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
 
-      await expect(controller.setBlacklisted(otherWallet.address, true)).to.emit(token, 'Blacklisted')
+      await expect(controller.addBlacklist(otherWallet.address)).to.emit(token, 'Blacklisted')
         .withArgs(otherWallet.address, true)
       await expect(controller.destroyBlackFunds(otherWallet.address)).to.emit(token, 'DestroyedBlackFunds')
-        .withArgs(otherWallet.address, balance).and.to.not.emit(token, 'Transfer')
+        .withArgs(otherWallet.address, balance)
 
       expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('0'))
-    })
-
-    it('rejects when destroying black funds for non blacklisted user', async () => {
-      await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
-      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
-      await expect(controller.destroyBlackFunds(otherWallet.address)).to.be.reverted
-
-      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
     })
 
     it('rejects when destroying black funds for blacklisted user by non owner', async () => {
       await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
       expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
 
-      await expect(controller.setBlacklisted(otherWallet.address, true)).to.emit(token, 'Blacklisted')
+      await expect(controller.addBlacklist(otherWallet.address)).to.emit(token, 'Blacklisted')
         .withArgs(otherWallet.address, true)
       await expect(controller.connect(otherWallet).destroyBlackFunds(otherWallet.address)).to.be.revertedWith('only Owner')
+      await expect(controller.connect(blacklistAdmin).destroyBlackFunds(otherWallet.address)).to.be.revertedWith('only Owner')
 
       expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
     })

--- a/packages/contracts-por/test/TokenController.test.ts
+++ b/packages/contracts-por/test/TokenController.test.ts
@@ -598,5 +598,29 @@ describe('TokenController', () => {
     it('rejects when called by non owner', async () => {
       await expect(controller.connect(otherWallet).setBlacklisted(otherWallet.address, true)).to.be.revertedWith('only Owner')
     })
+
+    it('destroy black funds for blacklisted user', async () => {
+      await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
+      const balance = await token.balanceOf(otherWallet.address)
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
+
+      await expect(controller.setBlacklisted(otherWallet.address, true)).to.emit(token, 'Blacklisted')
+        .withArgs(otherWallet.address, true)
+      await expect(controller.destroyBlackFunds(otherWallet.address)).to.emit(token, 'DestroyedBlackFunds')
+        .withArgs(otherWallet.address, balance).and.to.not.emit(token, 'Transfer')
+
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('0'))
+    })
+
+    it('rejects when destroying black funds for blacklisted user by non owner', async () => {
+      await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
+
+      await expect(controller.setBlacklisted(otherWallet.address, true)).to.emit(token, 'Blacklisted')
+        .withArgs(otherWallet.address, true)
+      await expect(controller.connect(otherWallet).destroyBlackFunds(otherWallet.address)).to.be.revertedWith('only Owner')
+
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
+    })
   })
 })


### PR DESCRIPTION
- The Owner or blackAdmins can be allowed to add blacklist operations;
- Only the Owner is allowed to delete the blacklist;
- Only the Owner is allowed to destroy funds of blacklisted users;
- Allows adding or removing blackAdmins
