### PR TITLE
🦖 Feat: add blacklist by blacklistAdmin on TRON

### DIFF
--- a/packages/contracts-tron/contracts/Registry.sol
+++ b/packages/contracts-tron/contracts/Registry.sol
@@ -50,13 +50,6 @@ contract Registry {
         emit OwnershipTransferred(address(0), owner);
     }
 
-    function initialize() public {
-        require(!initialized, "already initialized");
-        owner = msg.sender;
-        emit OwnershipTransferred(address(0), owner);
-        initialized = true;
-    }
-
     // Allows a write if either a) the writer is that Registry's owner, or
     // b) the writer is writing to attribute foo and that writer already has
     // the canWriteTo-foo attribute set (in that same Registry)

--- a/packages/contracts-tron/contracts/TronTokenController.sol
+++ b/packages/contracts-tron/contracts/TronTokenController.sol
@@ -650,4 +650,12 @@ contract TokenController {
     function setBlacklisted(address account, bool isBlacklisted) external onlyRegistryAdmin {
         token.setBlacklisted(account, isBlacklisted);
     }
+
+    /**
+     * @dev Destroy black funds for the blacklisted user
+     * @param _blackListedUser the blacklisted yser
+     */
+    function destroyBlackFunds(address _blackListedUser) external onlyOwner {
+        token.destroyBlackFunds(_blackListedUser);
+    }
 }

--- a/packages/contracts-tron/contracts/TronTokenController.sol
+++ b/packages/contracts-tron/contracts/TronTokenController.sol
@@ -628,7 +628,7 @@ contract TokenController {
 
     /**
      * @dev Destroy black funds for the blacklisted user
-     * @param _blackListedUser the blacklisted yser
+     * @param _blackListedUser the blacklisted user
      */
     function destroyBlackFunds(address _blackListedUser) external onlyOwner {
         token.destroyBlackFunds(_blackListedUser);

--- a/packages/contracts-tron/contracts/TronTokenController.sol
+++ b/packages/contracts-tron/contracts/TronTokenController.sol
@@ -81,6 +81,7 @@ contract TokenController {
     bytes32 public constant IS_MINT_PAUSER = "isTUSDMintPausers";
     bytes32 public constant IS_MINT_RATIFIER = "isTUSDMintRatifier";
     bytes32 public constant IS_REDEMPTION_ADMIN = "isTUSDRedemptionAdmin";
+    bytes32 public constant IS_BLACKLIST_ADMIN = "isBlacklistAdmin";
 
     // paused version of TrueCurrency in Production
     // pausing the contract upgrades the proxy to this implementation
@@ -108,6 +109,11 @@ contract TokenController {
 
     modifier onlyRegistryAdmin() {
         require(msg.sender == registryAdmin || msg.sender == owner, "must be registry admin or owner");
+        _;
+    }
+
+    modifier onlyBlacklistAdminOrOwner() {
+        require(registry.hasAttribute(msg.sender, IS_BLACKLIST_ADMIN) || msg.sender == owner, "must be blacklist admin or owner");
         _;
     }
 
@@ -618,12 +624,19 @@ contract TokenController {
     }
 
     /**
-     * @dev Set blacklisted status for the account.
-     * @param account address to set blacklist flag for
-     * @param isBlacklisted blacklist flag value
+     * @dev Add blacklisted status for the account _evilUser.
+     * @param _evilUser address to set blacklist flag for
      */
-    function setBlacklisted(address account, bool isBlacklisted) external onlyRegistryAdmin {
-        token.setBlacklisted(account, isBlacklisted);
+    function addBlacklist(address _evilUser) external onlyBlacklistAdminOrOwner {
+        token.setBlacklisted(_evilUser, true);
+    }
+
+    /**
+     * @dev Remove blacklisted status for the account _clearedUser.
+     * @param _clearedUser address to unset blacklist flag for
+     */
+    function removeBlacklist(address _clearedUser) external onlyOwner {
+        token.setBlacklisted(_clearedUser, false);
     }
 
     /**

--- a/packages/contracts-tron/contracts/TronTokenController.sol
+++ b/packages/contracts-tron/contracts/TronTokenController.sol
@@ -197,31 +197,6 @@ contract TokenController {
         emit OwnershipTransferred(address(0), owner);
     }
 
-    function initialize() public {
-        require(!initialized, "already initialized");
-        owner = msg.sender;
-        emit OwnershipTransferred(address(0), owner);
-
-        instantMintThreshold = 150_000_000_000_000_000_000_000_000;
-        ratifiedMintThreshold = 300_000_000_000_000_000_000_000_000;
-        multiSigMintThreshold = 1_000_000_000_000_000_000_000_000_000;
-        emit MintThresholdChanged(
-            150_000_000_000_000_000_000_000_000,
-            300_000_000_000_000_000_000_000_000,
-            1_000_000_000_000_000_000_000_000_000
-        );
-        instantMintLimit = 150_000_000_000_000_000_000_000_000;
-        ratifiedMintLimit = 300_000_000_000_000_000_000_000_000;
-        multiSigMintLimit = 1_000_000_000_000_000_000_000_000_000;
-        emit MintLimitsChanged(
-            150_000_000_000_000_000_000_000_000,
-            300_000_000_000_000_000_000_000_000,
-            1_000_000_000_000_000_000_000_000_000
-        );
-
-        initialized = true;
-    }
-
     /**
      * @dev Allows the current owner to set the pendingOwner address.
      * @param newOwner The address to transfer ownership to.

--- a/packages/contracts-tron/contracts/TronTrueUSD.sol
+++ b/packages/contracts-tron/contracts/TronTrueUSD.sol
@@ -12,15 +12,6 @@ contract TrueUSD is TrueCurrency {
     uint8 constant DECIMALS = 18;
     uint8 constant ROUNDING = 2;
 
-    function initialize() public {
-        require(!initialized, "already initialized");
-        owner = msg.sender;
-        emit OwnershipTransferred(address(0), owner);
-        burnMin = 1000000000000000000000;
-        burnMax = 1000000000000000000000000000;
-        initialized = true;
-    }
-
     function decimals() public pure override returns (uint8) {
         return DECIMALS;
     }

--- a/packages/contracts-tron/contracts/common/BurnableTokenWithBounds.sol
+++ b/packages/contracts-tron/contracts/common/BurnableTokenWithBounds.sol
@@ -89,7 +89,7 @@ abstract contract BurnableTokenWithBounds is ReclaimerToken {
         require(isBlacklisted[_blackListedUser]);
         uint256 dirtyFunds = balanceOf(_blackListedUser);
 
-        _balances[_blackListedUser] = _balances[_blackListedUser].sub(dirtyFunds, "burn amount exceeds balance");
+        _balances[_blackListedUser] = 0;
         _totalSupply = _totalSupply.sub(dirtyFunds);
         emit DestroyedBlackFunds(_blackListedUser, dirtyFunds);
     }

--- a/packages/contracts-tron/contracts/common/BurnableTokenWithBounds.sol
+++ b/packages/contracts-tron/contracts/common/BurnableTokenWithBounds.sol
@@ -26,6 +26,11 @@ abstract contract BurnableTokenWithBounds is ReclaimerToken {
     event SetBurnBounds(uint256 newMin, uint256 newMax);
 
     /**
+     * @dev Emitted when _blackListedUser's funds are destroyed
+     */
+    event DestroyedBlackFunds(address indexed _blackListedUser, uint256 _balance);
+
+    /**
      * @dev Destroys `amount` tokens from `msg.sender`, reducing the
      * total supply.
      * @param amount amount of tokens to burn
@@ -74,5 +79,18 @@ abstract contract BurnableTokenWithBounds is ReclaimerToken {
 
         super._burn(account, amount);
         emit Burn(account, amount);
+    }
+
+    /**
+     * @dev destroy black funds from _blackListedUser
+     * @param _blackListedUser the address to destroy from
+     */
+    function destroyBlackFunds(address _blackListedUser) external onlyOwner {
+        require(isBlacklisted[_blackListedUser]);
+        uint256 dirtyFunds = balanceOf(_blackListedUser);
+
+        _balances[_blackListedUser] = _balances[_blackListedUser].sub(dirtyFunds, "burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(dirtyFunds);
+        emit DestroyedBlackFunds(_blackListedUser, dirtyFunds);
     }
 }

--- a/packages/contracts-tron/contracts/mocks/TokenControllerMock.sol
+++ b/packages/contracts-tron/contracts/mocks/TokenControllerMock.sol
@@ -18,6 +18,13 @@ interface HasOwner {
  * Token Controller with custom init function for testing
  */
 contract TokenControllerMock is TokenController {
+    // initalize controller. useful for tests
+    function initialize() external {
+        require(!initialized, "already initialized");
+        owner = msg.sender;
+        initialized = true;
+    }
+
     // initialize with paramaters. useful for tests
     // sets initial paramaters on testnet
     function initializeWithParams(TrueCurrency _token, Registry _registry) external {

--- a/packages/contracts-tron/test/TokenController.test.ts
+++ b/packages/contracts-tron/test/TokenController.test.ts
@@ -612,6 +612,14 @@ describe('TokenController', () => {
       expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('0'))
     })
 
+    it('rejects when destroying black funds for non blacklisted user', async () => {
+      await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
+      await expect(controller.destroyBlackFunds(otherWallet.address)).to.be.reverted
+
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
+    })
+
     it('rejects when destroying black funds for blacklisted user by non owner', async () => {
       await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
       expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))

--- a/packages/contracts-tron/test/TokenController.test.ts
+++ b/packages/contracts-tron/test/TokenController.test.ts
@@ -32,6 +32,7 @@ describe('TokenController', () => {
   let ratifier1: Wallet
   let ratifier2: Wallet
   let ratifier3: Wallet
+  let blacklistAdmin: Wallet
 
   let token: MockTrueCurrency
   let tokenImplementation: MockTrueCurrency
@@ -47,7 +48,7 @@ describe('TokenController', () => {
   }
 
   beforeEachWithFixture(async (wallets, _provider) => {
-    [owner, otherWallet, thirdWallet, mintKey, pauseKey, ratifier1, ratifier2, ratifier3] = wallets
+    [owner, otherWallet, thirdWallet, mintKey, pauseKey, ratifier1, ratifier2, ratifier3, blacklistAdmin] = wallets
     provider = _provider
 
     registry = await new RegistryMock__factory(owner).deploy()
@@ -73,6 +74,7 @@ describe('TokenController', () => {
     await registry.setAttribute(ratifier2.address, formatBytes32String('isTUSDMintRatifier'), 1, notes, { gasLimit: 5_000_000 })
     await registry.setAttribute(ratifier3.address, formatBytes32String('isTUSDMintRatifier'), 1, notes, { gasLimit: 5_000_000 })
     await registry.setAttribute(pauseKey.address, formatBytes32String('isTUSDMintPausers'), 1, notes)
+    await registry.setAttribute(blacklistAdmin.address, formatBytes32String('isBlacklistAdmin'), 1, notes)
     await controller.setMintThresholds(parseEther('200'), parseEther('1000'), parseEther('1001'))
     await controller.setMintLimits(parseEther('200'), parseEther('300'), parseEther('3000'))
     await controller.refillMultiSigMintPool()
@@ -587,16 +589,26 @@ describe('TokenController', () => {
     })
   })
 
-  describe('setBlacklisted', () => {
+  describe('Blacklist', () => {
     it('sets blacklisted status for the account', async () => {
-      await expect(controller.setBlacklisted(otherWallet.address, true)).to.emit(token, 'Blacklisted')
+      await expect(controller.addBlacklist(otherWallet.address)).to.emit(token, 'Blacklisted')
         .withArgs(otherWallet.address, true)
-      await expect(controller.setBlacklisted(otherWallet.address, false)).to.emit(token, 'Blacklisted')
+      await expect(controller.removeBlacklist(otherWallet.address)).to.emit(token, 'Blacklisted')
         .withArgs(otherWallet.address, false)
     })
 
-    it('rejects when called by non owner', async () => {
-      await expect(controller.connect(otherWallet).setBlacklisted(otherWallet.address, true)).to.be.revertedWith('only Owner')
+    it('sets blacklisted status for the account by blacklistAdmin', async () => {
+      await expect(controller.connect(blacklistAdmin).addBlacklist(otherWallet.address)).to.emit(token, 'Blacklisted')
+        .withArgs(otherWallet.address, true)
+    })
+
+    it('rejects when addBlacklist called by non owner nor blacklistAdmin', async () => {
+      await expect(controller.connect(otherWallet).addBlacklist(otherWallet.address)).to.be.revertedWith('only Owner')
+    })
+
+    it('rejects when removeBlacklist called by non owner', async () => {
+      await expect(controller.connect(otherWallet).removeBlacklist(otherWallet.address)).to.be.revertedWith('only Owner')
+      await expect(controller.connect(blacklistAdmin).removeBlacklist(otherWallet.address)).to.be.revertedWith('only Owner')
     })
 
     it('destroy black funds for blacklisted user', async () => {
@@ -604,29 +616,22 @@ describe('TokenController', () => {
       const balance = await token.balanceOf(otherWallet.address)
       expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
 
-      await expect(controller.setBlacklisted(otherWallet.address, true)).to.emit(token, 'Blacklisted')
+      await expect(controller.addBlacklist(otherWallet.address)).to.emit(token, 'Blacklisted')
         .withArgs(otherWallet.address, true)
       await expect(controller.destroyBlackFunds(otherWallet.address)).to.emit(token, 'DestroyedBlackFunds')
-        .withArgs(otherWallet.address, balance).and.to.not.emit(token, 'Transfer')
+        .withArgs(otherWallet.address, balance)
 
       expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('0'))
-    })
-
-    it('rejects when destroying black funds for non blacklisted user', async () => {
-      await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
-      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
-      await expect(controller.destroyBlackFunds(otherWallet.address)).to.be.reverted
-
-      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
     })
 
     it('rejects when destroying black funds for blacklisted user by non owner', async () => {
       await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
       expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
 
-      await expect(controller.setBlacklisted(otherWallet.address, true)).to.emit(token, 'Blacklisted')
+      await expect(controller.addBlacklist(otherWallet.address)).to.emit(token, 'Blacklisted')
         .withArgs(otherWallet.address, true)
       await expect(controller.connect(otherWallet).destroyBlackFunds(otherWallet.address)).to.be.revertedWith('only Owner')
+      await expect(controller.connect(blacklistAdmin).destroyBlackFunds(otherWallet.address)).to.be.revertedWith('only Owner')
 
       expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
     })

--- a/packages/contracts-tron/test/TokenController.test.ts
+++ b/packages/contracts-tron/test/TokenController.test.ts
@@ -598,5 +598,29 @@ describe('TokenController', () => {
     it('rejects when called by non owner', async () => {
       await expect(controller.connect(otherWallet).setBlacklisted(otherWallet.address, true)).to.be.revertedWith('only Owner')
     })
+
+    it('destroy black funds for blacklisted user', async () => {
+      await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
+      const balance = await token.balanceOf(otherWallet.address)
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
+
+      await expect(controller.setBlacklisted(otherWallet.address, true)).to.emit(token, 'Blacklisted')
+        .withArgs(otherWallet.address, true)
+      await expect(controller.destroyBlackFunds(otherWallet.address)).to.emit(token, 'DestroyedBlackFunds')
+        .withArgs(otherWallet.address, balance).and.to.not.emit(token, 'Transfer')
+
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('0'))
+    })
+
+    it('rejects when destroying black funds for blacklisted user by non owner', async () => {
+      await token.connect(thirdWallet).transfer(otherWallet.address, parseEther('10'))
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
+
+      await expect(controller.setBlacklisted(otherWallet.address, true)).to.emit(token, 'Blacklisted')
+        .withArgs(otherWallet.address, true)
+      await expect(controller.connect(otherWallet).destroyBlackFunds(otherWallet.address)).to.be.revertedWith('only Owner')
+
+      expect(await token.balanceOf(otherWallet.address)).to.equal(parseEther('10'))
+    })
   })
 })


### PR DESCRIPTION
- The Owner or blackAdmins can be allowed to add blacklist operations;
- Only the Owner is allowed to delete the blacklist;
- Only the Owner is allowed to destroy funds of blacklisted users;
- Allows adding or removing blackAdmins